### PR TITLE
optimize net.InterfaceByName

### DIFF
--- a/netTamper/InterfaceByName_linux_test.go
+++ b/netTamper/InterfaceByName_linux_test.go
@@ -8,17 +8,17 @@ import (
 )
 
 // go test -bench=InterfaceBy -benchmem -run=none
-// optimize: 20% memory 5% CPU from output
+// optimize: 28% memory 3% CPU from output
 /*
 goos: linux
 goarch: amd64
 pkg: go-optimize/netTamper
 cpu: Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz
-Benchmark_TamperedInterfaceByName-4   	    6182	    188662 ns/op	   18084 B/op	      32 allocs/op
-Benchmark_NetInterfaceByName-4        	    5757	    193950 ns/op	   22840 B/op	      54 allocs/op
-Benchmark_NetInterfaceByIndex-4       	    6046	    187412 ns/op	   16196 B/op	      28 allocs/op
+Benchmark_TamperedInterfaceByName-4   	    6092	    187719 ns/op	   16068 B/op	      26 allocs/op
+Benchmark_NetInterfaceByName-4        	    5724	    194584 ns/op	   22840 B/op	      54 allocs/op
+Benchmark_NetInterfaceByIndex-4       	    6252	    187021 ns/op	   16196 B/op	      28 allocs/op
 PASS
-ok  	go-optimize/netTamper	3.487s
+ok  	go-optimize/netTamper	3.498s
 */
 
 func Test_TamperedInterfaceByName(t *testing.T) {
@@ -26,7 +26,7 @@ func Test_TamperedInterfaceByName(t *testing.T) {
 	assert.Nil(t, err)
 	expect, err := net.InterfaceByName("eth0")
 	assert.Nil(t, err)
-	assert.Equal(t, res, expect)
+	assert.Equal(t, expect, res)
 }
 
 func Benchmark_TamperedInterfaceByName(b *testing.B) {

--- a/netTamper/InterfaceByName_linux_test.go
+++ b/netTamper/InterfaceByName_linux_test.go
@@ -7,17 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// go test -bench=InterfaceByName -benchmem -run=none
+// go test -bench=InterfaceBy -benchmem -run=none
 // optimize: 20% memory 5% CPU from output
 /*
 goos: linux
 goarch: amd64
-pkg: test
+pkg: go-optimize/netTamper
 cpu: Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz
-Benchmark_TamperedInterfaceByName-4   	    6160	    187941 ns/op	   18152 B/op	      34 allocs/op
-Benchmark_NetInterfaceByName-4        	    5852	    194586 ns/op	   22840 B/op	      54 allocs/op
+Benchmark_TamperedInterfaceByName-4   	    6182	    188662 ns/op	   18084 B/op	      32 allocs/op
+Benchmark_NetInterfaceByName-4        	    5757	    193950 ns/op	   22840 B/op	      54 allocs/op
+Benchmark_NetInterfaceByIndex-4       	    6046	    187412 ns/op	   16196 B/op	      28 allocs/op
 PASS
-ok  	test	2.346s
+ok  	go-optimize/netTamper	3.487s
 */
 
 func Test_TamperedInterfaceByName(t *testing.T) {
@@ -37,5 +38,11 @@ func Benchmark_TamperedInterfaceByName(b *testing.B) {
 func Benchmark_NetInterfaceByName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		net.InterfaceByName("eth0")
+	}
+}
+
+func Benchmark_NetInterfaceByIndex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		net.InterfaceByIndex(1)
 	}
 }


### PR DESCRIPTION
make the function TamperedInterfaceByName() performance similar to net.InterfaceByIndex(), more efficient than net.InterfaceByName()